### PR TITLE
iceman can remove ice. BUG in description

### DIFF
--- a/IceMan/Actor.cpp
+++ b/IceMan/Actor.cpp
@@ -49,22 +49,34 @@ void Iceman::doSomething() {
 	if (!getIsActive()) // if not alive, return immediately
 		return;
 	// need to remove ice when iceman overlaps
+	if (getWorld()->icemanOverlaps(getX(), getY())) {
+		getWorld()->playSound(SOUND_DIG);
+	}
+	//std::cerr << getWorld()->icemanOverlaps(getX(), getY()) << std::endl;
 	int key = 0;
 	if (getWorld()->getKey(key) == true) {
 		switch (key) {
 		case KEY_PRESS_LEFT:
+			if (getX() == 0)
+				break;
 			setDirection(left);
 			moveTo(getX() - 1, getY());
 			break;
 		case KEY_PRESS_RIGHT:
+			if (getX() == VIEW_WIDTH - 4)
+				break;
 			setDirection(right);
 			moveTo(getX() + 1, getY());
 			break;
 		case KEY_PRESS_DOWN:
+			if (getY() == 0)
+				break;
 			setDirection(down);
 			moveTo(getX(), getY() - 1);
 			break;
 		case KEY_PRESS_UP:
+			if (getY() == VIEW_HEIGHT - 4)
+				break;
 			setDirection(up);
 			moveTo(getX(), getY() + 1);
 			break;

--- a/IceMan/StudentWorld.cpp
+++ b/IceMan/StudentWorld.cpp
@@ -223,3 +223,51 @@ bool StudentWorld::isThereIce(int xPos, int yPos)
 	}
 	return false;
 }
+
+bool StudentWorld::icemanOverlaps(int x, int y) {
+	// delete the overlapping ice accordint to the direction that the iceman is facing
+
+	if (isThereIce(x, y) && icemanPtr->getDirection() == Iceman::left) { 
+		for (int i = 0; i < 4; i++) {
+			if (icePtr[x][y + i] == nullptr) // to prevent double deletion
+				break;
+			cerr << "deleting left coordinates: " << x << " " << y + i << endl;
+			delete icePtr[x][y + i];
+			icePtr[x][y + i] = nullptr;
+		}
+		return true;
+
+	}
+	else if (isThereIce(x, y) && icemanPtr->getDirection() == Iceman::right) {
+		for (int i = 0; i < 4; i++) {
+			if (icePtr[x + 3][y + i] == nullptr)
+				break;
+			cerr << "deleting right coordinates: " << x + 4 << " " << y + i << endl;
+			delete icePtr[x + 3][y + i];
+			icePtr[x + 3][y + i] = nullptr;
+		}
+		return true;
+
+	}
+	else if (isThereIce(x, y) && icemanPtr->getDirection() == Iceman::down) {
+		for (int i = 0; i < 4; i++) {
+			if (icePtr[x + i][y] == nullptr)
+				break;
+			delete icePtr[x + i][y];
+			icePtr[x + i][y] = nullptr;
+		}
+		return true;
+
+	}
+	else if (isThereIce(x, y) && icemanPtr->getDirection() == Iceman::up) {
+		for (int i = 0; i < 4; i++) {
+			if (icePtr[x + i][y + 3] == nullptr)
+				break;
+			delete icePtr[x + i][y + 3];
+			icePtr[x + i][y + 3] = nullptr;
+		}
+		return true;
+
+	}
+	return false;
+}

--- a/IceMan/StudentWorld.h
+++ b/IceMan/StudentWorld.h
@@ -51,7 +51,13 @@ public:
 		//populateWaterSquirt(); // this is probably in move since it only is populated once iceman shoots
 		//populateSonarKit(); // i think this also occurs later in the game
 		//populateProtestors();
-
+		//delete icePtr[29][59];
+		//delete icePtr[29][60];
+		//delete icePtr[29][61];
+		//delete icePtr[29][62];
+		//delete icePtr[29][58];
+		//delete icePtr[30][0];
+		//delete icePtr[29][60];
 
 		return GWSTATUS_CONTINUE_GAME;
 	}
@@ -77,6 +83,8 @@ public:
 	//bool isThereIceAround(int xPos, int yPos);
 	void deleteInactiveActors();
 	bool isThereIce(int xPos, int yPos);
+	bool icemanOverlaps(int x, int y);
+
 	virtual int move()
 	{
 		// This code is here merely to allow the game to build, run, and terminate after you hit enter a few times.


### PR DESCRIPTION
When iceman moves along the row in which he spawns, ice is removed from the bottom. I believe this has something to do with the fact that the map and the 2D array y-coordinates are inverted. I noticed that the coordinates icePtr[30][0] are the same as icePtr[29][60]. Very weird. [29][60] should be invalid since the ice is only 59 units high, but it instead accesses the 0'th row. The x coordinate is also ahead by 1.